### PR TITLE
Fix call stack display and styling

### DIFF
--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders main heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/Sorting Algorithm Stability Visualizer/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/client/src/components/Visualizer.js
+++ b/client/src/components/Visualizer.js
@@ -74,54 +74,42 @@ function Visualizer({ array, highlights, pseudocode, pseudocodeLine, callLog, cu
         {/* Call Stack Log Panel: Displays the dynamic call stack of the algorithm. */}
         {/* flex-1 for width, h-full to fill parent height, overflow-auto for independent scrolling. */}
         <div className="flex-1 overflow-auto bg-gray-50 p-4 rounded-lg shadow-inner h-full">
-          <h3 className="text-lg font-semibold mb-2 text-gray-800">Call Stack Log</h3>
+          <h3 className="text-lg font-semibold mb-2 text-gray-800">Call Stack</h3>
           {callLog.length === 0 ? (
             <p className="text-gray-500 text-sm">Call stack will appear here as the algorithm runs.</p>
           ) : (
-            <div className="space-y-2">
+            <div className="space-y-2 font-mono text-xs">
               {callLog.map((frame, index) => (
                 <div
                   key={index}
-                  className={`p-2 rounded-md transition-all duration-200 ease-in-out
-                    ${frame.type === 'call' ? 'bg-blue-100' : 'bg-green-100'}
+                  className={`p-2 rounded transition-colors duration-200
+                    ${frame.type === 'call' ? 'bg-blue-50' : 'bg-green-50'}
                     ${index === currentStepIndex ? 'border-2 border-blue-500 shadow-md' : 'border border-gray-200'}
                   `}
-                  style={{ marginLeft: frame.locals?.callDepth ? `${frame.locals.callDepth * 15}px` : '0px' }}
+                  style={{ marginLeft: frame.locals?.callDepth ? `${frame.locals.callDepth * 20}px` : '0px' }}
                 >
-                  <div className="flex items-center space-x-2 text-sm font-medium text-gray-700">
+                  <div className="flex items-center space-x-1">
                     {frame.type === 'call' && (
-                      <span className="text-blue-600">CALL:</span>
+                      <span className="text-blue-600">&#9656;</span>
                     )}
                     {frame.type === 'return' && (
-                      <span className="text-green-600">RETURN:</span>
+                      <span className="text-green-600">&#9666;</span>
                     )}
-                    <span className="font-semibold">{frame.name}</span>
-                    {frame.locals?.callDepth !== undefined && (
-                      <span className="text-gray-500 text-xs">(Depth: {frame.locals.callDepth})</span>
-                    )}
+                    <span className="font-semibold text-gray-800">{frame.name}</span>
                     {frame.line !== undefined && (
-                      <span className="text-gray-500 text-xs">(Line: {frame.line})</span>
+                      <span className="text-gray-500">(line {frame.line})</span>
                     )}
                   </div>
                   {frame.args && frame.args.length > 0 && (
-                    <div className="ml-4 text-xs text-gray-600">
-                      Args: {frame.args.map(arg => formatValue(arg)).join(', ')}
-                    </div>
+                    <div className="ml-4 text-gray-700">Args: {frame.args.map(arg => formatValue(arg)).join(', ')}</div>
                   )}
                   {frame.locals && Object.keys(frame.locals).length > 0 && (
-                    <div className="ml-4 text-xs text-gray-600">
-                      Locals:
-                      {Object.entries(frame.locals).map(([key, value]) => (
-                        <div key={key} className="ml-2">
-                          {key}: {formatValue(value)}
-                        </div>
-                      ))}
-                    </div>
+                    <div className="ml-4 text-gray-700">Locals: {Object.entries(frame.locals).map(([key, value]) => (
+                      <span key={key} className="mr-2">{key}: {formatValue(value)}</span>
+                    ))}</div>
                   )}
                   {frame.type === 'return' && frame.returnValue !== undefined && (
-                    <div className="ml-4 text-xs text-green-700 font-medium">
-                      Returns: {formatValue(frame.returnValue)}
-                    </div>
+                    <div className="ml-4 text-green-700">Returns: {formatValue(frame.returnValue)}</div>
                   )}
                 </div>
               ))}


### PR DESCRIPTION
## Summary
- compute call depth dynamically when processing events
- reset call depth between sorts
- modernize call stack UI
- update basic test for app header

## Testing
- `npm test --silent --runTestsByPath src/App.test.js`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686a9b57bacc832db1d00197db0ac3ba